### PR TITLE
user: Fix SQL error relating to um.meta_value invoking GetUser.

### DIFF
--- a/user.go
+++ b/user.go
@@ -56,7 +56,7 @@ func GetUsers(c context.Context, userIds ...int64) ([]*User, error) {
 		From(table(c, "users") + " AS u").
 		Join(table(c, "usermeta") + " AS um ON um.user_id = u.ID").
 		Where(sqrl.Eq{"meta_key": "description"}).
-		GroupBy("u.ID").
+		GroupBy("u.ID, um.meta_value").
 		Where(sqrl.Eq{"u.ID": ids}).ToSql()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the following error:

```
Expression #4 of SELECT list is not in GROUP BY clause and contains
    nonaggregated column 'DBNAMEHERE.um.meta_value' which is not functionally
    dependent on columns in GROUP BY clause; this is incompatible with
    sql_mode=only_full_group
```

This happens even when there is no duplicate `meta_key = "description"`.

```
mysql> SELECT meta_key, COUNT(*) AS c FROM wp_usermeta WHERE user_id = 1
    GROUP BY meta_key HAVING c > 1;
Empty set (0.00 sec)
```

Fixes #1.