### PR TITLE
Switch to using OpenCensus for tracing.

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -1,7 +1,7 @@
 package wordpress
 
 import (
-	"cloud.google.com/go/trace"
+	"go.opencensus.io/trace"
 	"github.com/wulijun/go-php-serialize/phpserialize"
 	"golang.org/x/net/context"
 )
@@ -23,10 +23,8 @@ type Attachment struct {
 
 // GetAttachments gets all attachment data from the database
 func GetAttachments(c context.Context, attachmentIds ...int64) ([]*Attachment, error) {
-	span := trace.FromContext(c).NewChild("/wordpress.GetAttachments")
-	defer span.Finish()
-
-	c = trace.NewContext(c, span)
+	c, span := trace.StartSpan(c, "/wordpress.GetAttachments")
+	defer span.End()
 
 	if len(attachmentIds) == 0 {
 		return nil, nil
@@ -100,10 +98,10 @@ func GetAttachments(c context.Context, attachmentIds ...int64) ([]*Attachment, e
 
 // QueryAttachments returns the ids of the attachments that match the query
 func QueryAttachments(c context.Context, opts *ObjectQueryOptions) (Iterator, error) {
-	span := trace.FromContext(c).NewChild("/wordpress.QueryAttachments")
-	defer span.Finish()
+	c, span := trace.StartSpan(c, "/wordpress.QueryAttachments")
+	defer span.End()
 
 	opts.PostType = PostTypeAttachment
 
-	return queryObjects(trace.NewContext(c, span), opts)
+	return queryObjects(c, opts)
 }

--- a/post.go
+++ b/post.go
@@ -1,7 +1,7 @@
 package wordpress
 
 import (
-	"cloud.google.com/go/trace"
+	"go.opencensus.io/trace"
 	"golang.org/x/net/context"
 	"strconv"
 )
@@ -25,10 +25,8 @@ type Post struct {
 
 // GetPosts gets all post data from the database
 func GetPosts(c context.Context, postIds ...int64) ([]*Post, error) {
-	span := trace.FromContext(c).NewChild("/wordpress.GetPosts")
-	defer span.Finish()
-
-	c = trace.NewContext(c, span)
+	c, span := trace.StartSpan(c, "/wordpress.GetPosts")
+	defer span.End()
 
 	if len(postIds) == 0 {
 		return nil, nil
@@ -108,8 +106,8 @@ func GetPosts(c context.Context, postIds ...int64) ([]*Post, error) {
 
 // QueryPosts returns the ids of the posts that match the query
 func QueryPosts(c context.Context, opts *ObjectQueryOptions) (Iterator, error) {
-	span := trace.FromContext(c).NewChild("/wordpress.QueryPosts")
-	defer span.Finish()
+	c, span := trace.StartSpan(c, "/wordpress.QueryPosts")
+	defer span.End()
 
 	opts.PostStatus = PostStatusPublish
 

--- a/tag.go
+++ b/tag.go
@@ -1,7 +1,7 @@
 package wordpress
 
 import (
-	"cloud.google.com/go/trace"
+	"go.opencensus.io/trace"
 	"encoding/json"
 	"golang.org/x/net/context"
 )
@@ -23,8 +23,8 @@ func (tag *Tag) MarshalJSON() ([]byte, error) {
 
 // GetTags gets all tag data from the database
 func GetTags(c context.Context, tagIds ...int64) ([]*Tag, error) {
-	span := trace.FromContext(c).NewChild("/wordpress.GetTags")
-	defer span.Finish()
+	c, span := trace.StartSpan(c, "/wordpress.GetTags")
+	defer span.End()
 
 	if len(tagIds) == 0 {
 		return nil, nil

--- a/term.go
+++ b/term.go
@@ -1,7 +1,7 @@
 package wordpress
 
 import (
-	"cloud.google.com/go/trace"
+	"go.opencensus.io/trace"
 	"encoding/base64"
 	"fmt"
 	"github.com/elgris/sqrl"
@@ -85,7 +85,7 @@ func getTerms(c context.Context, termIds ...int64) ([]*Term, error) {
 		return nil, err
 	}
 
-	trace.FromContext(c).SetLabel("wp/term/query", stmt)
+	trace.FromContext(c).AddAttributes(trace.StringAttribute("wp/term/query", stmt))
 
 	rows, err := database(c).Query(stmt, args...)
 	if err != nil {
@@ -114,7 +114,7 @@ func getTerms(c context.Context, termIds ...int64) ([]*Term, error) {
 		}
 	}
 
-	trace.FromContext(c).SetLabel("wp/term/count", strconv.Itoa(len(ret)))
+	trace.FromContext(c).AddAttributes(trace.Int64Attribute("wp/term/count", int64(len(ret))))
 
 	var mre MissingResourcesError
 	for i, term := range ret {
@@ -233,7 +233,7 @@ func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
 		return nil, err
 	}
 
-	trace.FromContext(c).SetLabel("wp/term/query", sql)
+	trace.FromContext(c).AddAttributes(trace.StringAttribute("wp/term/query", sql))
 
 	rows, err := database(c).Query(sql, args...)
 	if err != nil {
@@ -250,7 +250,7 @@ func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
 		ids = append(ids, id)
 	}
 
-	trace.FromContext(c).SetLabel("wp/term/count", strconv.Itoa(len(ids)))
+	trace.FromContext(c).AddAttributes(trace.Int64Attribute("wp/term/count", int64(len(ids))))
 
 	it := iteratorImpl{cursor: opts.After}
 


### PR DESCRIPTION
cloud.google.com/go/trace has been removed from cloud.google.com/go
repository as of dc456904c5ef3d6d21c01ce09dfce15891aa3cea, which suggests
referring to https://cloud.google.com/trace/docs/setup/go.

Per https://cloud.google.com/trace/docs/setup/go, the suggested action
is to adopt go.opencensus.io.

Fixes #3.