### PR TITLE
post: Do not unconditionally override opts.PostStatus.

### DIFF
--- a/post.go
+++ b/post.go
@@ -109,7 +109,9 @@ func QueryPosts(c context.Context, opts *ObjectQueryOptions) (Iterator, error) {
 	c, span := trace.StartSpan(c, "/wordpress.QueryPosts")
 	defer span.End()
 
-	opts.PostStatus = PostStatusPublish
+	if opts.PostStatus == "" {
+		opts.PostStatus = PostStatusPublish
+	}
 
 	if opts.PostType == "" {
 		opts.PostType = PostTypePost


### PR DESCRIPTION
As is, we could only fetch posts that were published.

This created a problem for fetching posts in any other state (including 'inherit').