### PR TITLE
Enable querying for terms (post_tag and category) from client code by adding to public interface

### DIFF
--- a/term.go
+++ b/term.go
@@ -133,7 +133,11 @@ func getTerms(c context.Context, termIds ...int64) ([]*Term, error) {
 	return ret, nil
 }
 
-// queryTerms returns the ids of the terms that match the query
+// QueryTerms returns the ids of the terms that match the query
+func QueryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
+	return queryTerms(c, opts)
+}
+
 func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
 	order := opts.Order
 	if len(order) == 0 {

--- a/term.go
+++ b/term.go
@@ -44,6 +44,9 @@ type TermQueryOptions struct {
 	After string `param:"after"`
 	Limit int    `param:"limit"`
 
+	Order          string `param:"order_by"`
+	OrderAscending bool   `param:"order_asc"`
+
 	Id      int64   `param:"term_id"`
 	IdIn    []int64 `param:"term_id__in"`
 	IdNotIn []int64 `param:"term_id__not_in"`
@@ -132,9 +135,20 @@ func getTerms(c context.Context, termIds ...int64) ([]*Term, error) {
 
 // queryTerms returns the ids of the terms that match the query
 func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
+	order := opts.Order
+	if len(order) == 0 {
+		order = "t.term_id ASC"
+	} else {
+		if opts.OrderAscending {
+			order += " ASC"
+		} else {
+			order += " DESC"
+		}
+	}
+
 	q := sqrl.Select("t.term_id").
 		From(table(c, "terms") + " AS t").
-		OrderBy("t.term_id ASC")
+		OrderBy(order)
 
 	var requireTaxonomy, requireRelationships bool
 
@@ -208,9 +222,24 @@ func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
 	if opts.After != "" {
 		// ignore `q.After` if any errors occur
 		if b, err := base64.URLEncoding.DecodeString(opts.After); err == nil {
-			q = q.Where("t.term_id > ?", string(b))
+			pred := opts.Order
+			if len(pred) == 0 {
+				pred = "t.term_id"
+			}
+			
+			if opts.OrderAscending {
+				pred += ">"
+			} else {
+				pred += "<"
+			}
+
+			pred += " ?"
+
+			q = q.Where(pred, string(b))
 		}
 	}
+
+	q = q.OrderBy(order)
 
 	if opts.Limit == 0 {
 		opts.Limit = 10

--- a/term.go
+++ b/term.go
@@ -1,10 +1,10 @@
 package wordpress
 
 import (
-	"go.opencensus.io/trace"
 	"encoding/base64"
 	"fmt"
 	"github.com/elgris/sqrl"
+	"go.opencensus.io/trace"
 	"golang.org/x/net/context"
 	"strconv"
 )
@@ -230,7 +230,7 @@ func queryTerms(c context.Context, opts *TermQueryOptions) (Iterator, error) {
 			if len(pred) == 0 {
 				pred = "t.term_id"
 			}
-			
+
 			if opts.OrderAscending {
 				pred += ">"
 			} else {


### PR DESCRIPTION
Years ago, while implementing sitemaps, I needed to write a custom query to get for posts by tags or categories.

Example of what I was doing (`taxonomy` is either `post_tag` or `category`):

```go
        us := SitemapURLSet{}
        it, err := wordpress.QueryTerms(wpctx, &wordpress.TermQueryOptions{
                Taxonomy:       wordpress.Taxonomy(taxonomy),
                Order:          "slug",
                OrderAscending: true,
                Limit:          32767, // "everything" (rather than up to 10)
        })
        if err != nil {
                glog.Errorf("could not get terms for taxonomy %q: %v", taxonomy, err)
                http.Error(w, "could not get terms", http.StatusInternalServerError)
                return
        }
```


I also needed to be able to order by a certain field and to choose whether to order ascending or descending, so that ended up in there as well.

Example of how I was generating sitemap for a user using descending order by when post was modified (not created etc, since this is for search engines and other indexers to know to update the scraped page):

```go
it, err := wordpress.QueryPosts(wpctx, &wordpress.ObjectQueryOptions{Author: user.Id, Limit: 1, Order: "post_modified_gmt", OrderAscending: false, PostType: wordpress.PostTypePost})
```

Note, I have actually never completed the site rendering the blog using this library, so I can't just point at it, but I still have a bit of hope to do so.