### PR TITLE
wordpress: Make Database and Table into public functions.

### DIFF
--- a/wordpress.go
+++ b/wordpress.go
@@ -76,6 +76,14 @@ func database(c context.Context) *sql.DB {
 	return db
 }
 
+func Database(c context.Context) *sql.DB {
+	return database(c)
+}
+
+func Table(c context.Context, tableN string) string {
+	return table(c, tableN)
+}
+
 // GetOption returns the string value of the WordPress option
 func GetOption(c context.Context, name string) (string, error) {
 	c, span := trace.StartSpan(c, "/wordpress.GetOption")


### PR DESCRIPTION
This was useful when constructing a manual `sqrl.Select` query to generate index of sub-sitemaps compatible with a sitemap plugin currently used on a personal blog, and which needs to contain a somewhat accurate 'last modified' value. 

The constructed `sqrl` query needs access to 'posts' table, and invocation using q.Run requires the database itself, so making this public allows both to be 'extracted' from the context object and allows for a custom query to be submitted without having to establish another custom connection for either `sqlr` or something else to use.

Example of the query:

```go
         q := sqrl.Select()
         q = q.Column(sqrl.Alias(sqrl.Expr("MAX(post_modified_gmt)"), "last_changed"))
         q = q.Column(sqrl.Alias(sqrl.Expr("COUNT(id)"), "cnt"))
         q = q.Column(sqrl.Alias(sqrl.Expr("YEAR(wp_posts.post_date_gmt)"), "y"))
         q = q.Column(sqrl.Alias(sqrl.Expr("MONTH(wp_posts.post_date_gmt)"), "m"))
         q = q.Column("post_type")
         q = q.From(wordpress.Table(wpctx, "posts"))
         q = q.Where(sqrl.Eq{"post_type": []string{"post", "page"}})
         q = q.GroupBy("y", "m", "post_type")
         q = q.OrderBy("post_type DESC", "y DESC", "m DESC")
         db := wordpress.Database(wpctx)

         rows, err := q.RunWith(db).QueryContext(wpctx)
```