### PR TITLE
go.mod: Use opencensus 0.22 and specify Go 1.14.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
 module github.com/ssttevee/go-wordpress
 
+go 1.14
+
 require (
 	cloud.google.com/go v0.45.0
 	github.com/elgris/sqrl v0.0.0-20190909141434-5a439265eeec
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/wulijun/go-php-serialize v0.0.0-20131104125240-bfe692b0100e
+	go.opencensus.io v0.22.0
 	golang.org/x/net v0.0.0-20201002202402-0a1ea396d57c
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/wulijun/go-php-serialize v0.0.0-20131104125240-bfe692b0100e h1:RvQKfrutTG8kkNKn9kTm0YHfEGS8xXhoptD9wjdTvww=
 github.com/wulijun/go-php-serialize v0.0.0-20131104125240-bfe692b0100e/go.mod h1:4r5LO7ogv60g1dbSz2NRTsUEAcD5sh5K5xbwjHfN2Oc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
I've had these changes for years in my local branch, uncertain when from (2021, likely). They might not be necessary, but I think `go mod tidy` did them at the time.